### PR TITLE
Fix Invalid characters passed for attempted conversion (7.4)

### DIFF
--- a/src/Object/AbstractObject.php
+++ b/src/Object/AbstractObject.php
@@ -429,8 +429,8 @@ abstract class AbstractObject implements ObjectInterface
      */
     public function setForeColor($value)
     {
-        if (preg_match('`\#[0-9A-F]{6}`', $value)) {
-            $this->foreColor = hexdec($value);
+        if (preg_match('`\#([0-9A-F]{6})`', $value, $reg)) {
+            $this->foreColor = hexdec($reg[1]);
         } elseif (is_numeric($value) && $value >= 0 && $value <= 16777125) {
             $this->foreColor = intval($value);
         } else {
@@ -460,8 +460,8 @@ abstract class AbstractObject implements ObjectInterface
      */
     public function setBackgroundColor($value)
     {
-        if (preg_match('`\#[0-9A-F]{6}`', $value)) {
-            $this->backgroundColor = hexdec($value);
+        if (preg_match('`\#([0-9A-F]{6})`', $value, $reg)) {
+            $this->backgroundColor = hexdec($reg[1]);
         } elseif (is_numeric($value) && $value >= 0 && $value <= 16777125) {
             $this->backgroundColor = intval($value);
         } else {


### PR DESCRIPTION
Running test suite with PHP 7.4.1

```
There were 36 errors:

1) ZendTest\Barcode\Object\CodabarTest::testForeColor
Invalid characters passed for attempted conversion, these have been ignored

/dev/shm/BUILDROOT/php-zendframework-zend-barcode-2.8.0-1.fc31.remi.x86_64/usr/share/php/Zend/Barcode/Object/AbstractObject.php:432
/dev/shm/BUILD/zend-barcode-6db95687997920b8217e71d2f12b51ec10e824d9/test/Object/TestCommon.php:160

2) ZendTest\Barcode\Object\CodabarTest::testBackgroundColor
Invalid characters passed for attempted conversion, these have been ignored

/dev/shm/BUILDROOT/php-zendframework-zend-barcode-2.8.0-1.fc31.remi.x86_64/usr/share/php/Zend/Barcode/Object/AbstractObject.php:463
/dev/shm/BUILD/zend-barcode-6db95687997920b8217e71d2f12b51ec10e824d9/test/Object/TestCommon.php:180

3) ZendTest\Barcode\Object\Code128Test::testForeColor
Invalid characters passed for attempted conversion, these have been ignored

/dev/shm/BUILDROOT/php-zendframework-zend-barcode-2.8.0-1.fc31.remi.x86_64/usr/share/php/Zend/Barcode/Object/AbstractObject.php:432
/dev/shm/BUILD/zend-barcode-6db95687997920b8217e71d2f12b51ec10e824d9/test/Object/TestCommon.php:160

4) ZendTest\Barcode\Object\Code128Test::testBackgroundColor
Invalid characters passed for attempted conversion, these have been ignored

/dev/shm/BUILDROOT/php-zendframework-zend-barcode-2.8.0-1.fc31.remi.x86_64/usr/share/php/Zend/Barcode/Object/AbstractObject.php:463
/dev/shm/BUILD/zend-barcode-6db95687997920b8217e71d2f12b51ec10e824d9/test/Object/TestCommon.php:180


etc
```

In short `#` must be removed from `$value`