### PR TITLE
Fix tests on Windows machine

### DIFF
--- a/test/Renderer/SvgTest.php
+++ b/test/Renderer/SvgTest.php
@@ -29,15 +29,13 @@ class SvgTest extends TestCommon
      */
     public function testSvgNoTransparency()
     {
-        $svgCompare = file_get_contents(__DIR__ . '/_files/svg_transparency.xml');
-
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/../Object/_fonts/Vera.ttf');
         $barcode = new Code39(['text' => '0123456789']);
         $this->renderer->setBarcode($barcode);
 
         $this->assertFalse($this->renderer->getTransparentBackground());
         $svgOutput = $this->renderer->draw()->saveXML();
-        $this->assertNotEquals($svgCompare, $svgOutput);
+        $this->assertXmlStringEqualsXmlFile(__DIR__ . '/_files/svg_no_transparency.xml', $svgOutput);
     }
 
     /**
@@ -47,28 +45,24 @@ class SvgTest extends TestCommon
      */
     public function testSvgTransparency()
     {
-        $svgCompare = file_get_contents(__DIR__ . '/_files/svg_transparency.xml');
-
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/../Object/_fonts/Vera.ttf');
         $barcode = new Code39(['text' => '0123456789']);
         $this->renderer->setBarcode($barcode);
         $this->renderer->setTransparentBackground(true);
         $this->assertTrue($this->renderer->getTransparentBackground());
         $svgOutput = $this->renderer->draw()->saveXML();
-        $this->assertEquals($svgCompare, $svgOutput);
+        $this->assertXmlStringEqualsXmlFile(__DIR__ . '/_files/svg_transparency.xml', $svgOutput);
     }
 
     public function testSvgOrientation()
     {
-        $svgCompare = file_get_contents(__DIR__ . '/_files/svg_oriented.xml');
-
         Barcode\Barcode::setBarcodeFont(__DIR__ . '/../Object/_fonts/Vera.ttf');
         $barcode = new Code39(['text' => '0123456789', 'orientation' => 270]);
         $this->renderer->setBarcode($barcode);
         $this->renderer->setTransparentBackground(true);
         $this->assertTrue($this->renderer->getTransparentBackground());
         $svgOutput = $this->renderer->draw()->saveXML();
-        $this->assertEquals($svgCompare, $svgOutput);
+        $this->assertXmlStringEqualsXmlFile(__DIR__ . '/_files/svg_oriented.xml', $svgOutput);
     }
 
     public function testType()

--- a/test/Renderer/_files/svg_no_transparency.xml
+++ b/test/Renderer/_files/svg_no_transparency.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="211" height="62">
+  <title>Barcode CODE39 *0123456789*</title>
+  <rect x="0" y="0" width="210" height="61" fill="rgb(255,255,255)"/>
+  <polygon points="0 0 0 61 211 61 211 0" fill="rgb(255,255,255)"/>
+  <polygon points="10 0 10 50 11 50 11 0" fill="rgb(0,0,0)"/>
+  <polygon points="14 0 14 50 15 50 15 0" fill="rgb(0,0,0)"/>
+  <polygon points="16 0 16 50 19 50 19 0" fill="rgb(0,0,0)"/>
+  <polygon points="20 0 20 50 23 50 23 0" fill="rgb(0,0,0)"/>
+  <polygon points="24 0 24 50 25 50 25 0" fill="rgb(0,0,0)"/>
+  <polygon points="26 0 26 50 27 50 27 0" fill="rgb(0,0,0)"/>
+  <polygon points="28 0 28 50 29 50 29 0" fill="rgb(0,0,0)"/>
+  <polygon points="32 0 32 50 35 50 35 0" fill="rgb(0,0,0)"/>
+  <polygon points="36 0 36 50 39 50 39 0" fill="rgb(0,0,0)"/>
+  <polygon points="40 0 40 50 41 50 41 0" fill="rgb(0,0,0)"/>
+  <polygon points="42 0 42 50 45 50 45 0" fill="rgb(0,0,0)"/>
+  <polygon points="46 0 46 50 47 50 47 0" fill="rgb(0,0,0)"/>
+  <polygon points="50 0 50 50 51 50 51 0" fill="rgb(0,0,0)"/>
+  <polygon points="52 0 52 50 53 50 53 0" fill="rgb(0,0,0)"/>
+  <polygon points="54 0 54 50 57 50 57 0" fill="rgb(0,0,0)"/>
+  <polygon points="58 0 58 50 59 50 59 0" fill="rgb(0,0,0)"/>
+  <polygon points="60 0 60 50 63 50 63 0" fill="rgb(0,0,0)"/>
+  <polygon points="66 0 66 50 67 50 67 0" fill="rgb(0,0,0)"/>
+  <polygon points="68 0 68 50 69 50 69 0" fill="rgb(0,0,0)"/>
+  <polygon points="70 0 70 50 73 50 73 0" fill="rgb(0,0,0)"/>
+  <polygon points="74 0 74 50 77 50 77 0" fill="rgb(0,0,0)"/>
+  <polygon points="78 0 78 50 81 50 81 0" fill="rgb(0,0,0)"/>
+  <polygon points="84 0 84 50 85 50 85 0" fill="rgb(0,0,0)"/>
+  <polygon points="86 0 86 50 87 50 87 0" fill="rgb(0,0,0)"/>
+  <polygon points="88 0 88 50 89 50 89 0" fill="rgb(0,0,0)"/>
+  <polygon points="90 0 90 50 91 50 91 0" fill="rgb(0,0,0)"/>
+  <polygon points="92 0 92 50 93 50 93 0" fill="rgb(0,0,0)"/>
+  <polygon points="96 0 96 50 99 50 99 0" fill="rgb(0,0,0)"/>
+  <polygon points="100 0 100 50 101 50 101 0" fill="rgb(0,0,0)"/>
+  <polygon points="102 0 102 50 105 50 105 0" fill="rgb(0,0,0)"/>
+  <polygon points="106 0 106 50 109 50 109 0" fill="rgb(0,0,0)"/>
+  <polygon points="110 0 110 50 111 50 111 0" fill="rgb(0,0,0)"/>
+  <polygon points="114 0 114 50 117 50 117 0" fill="rgb(0,0,0)"/>
+  <polygon points="118 0 118 50 119 50 119 0" fill="rgb(0,0,0)"/>
+  <polygon points="120 0 120 50 121 50 121 0" fill="rgb(0,0,0)"/>
+  <polygon points="122 0 122 50 123 50 123 0" fill="rgb(0,0,0)"/>
+  <polygon points="124 0 124 50 127 50 127 0" fill="rgb(0,0,0)"/>
+  <polygon points="130 0 130 50 133 50 133 0" fill="rgb(0,0,0)"/>
+  <polygon points="134 0 134 50 135 50 135 0" fill="rgb(0,0,0)"/>
+  <polygon points="136 0 136 50 137 50 137 0" fill="rgb(0,0,0)"/>
+  <polygon points="138 0 138 50 139 50 139 0" fill="rgb(0,0,0)"/>
+  <polygon points="140 0 140 50 141 50 141 0" fill="rgb(0,0,0)"/>
+  <polygon points="144 0 144 50 145 50 145 0" fill="rgb(0,0,0)"/>
+  <polygon points="146 0 146 50 149 50 149 0" fill="rgb(0,0,0)"/>
+  <polygon points="150 0 150 50 153 50 153 0" fill="rgb(0,0,0)"/>
+  <polygon points="154 0 154 50 157 50 157 0" fill="rgb(0,0,0)"/>
+  <polygon points="158 0 158 50 159 50 159 0" fill="rgb(0,0,0)"/>
+  <polygon points="162 0 162 50 163 50 163 0" fill="rgb(0,0,0)"/>
+  <polygon points="164 0 164 50 167 50 167 0" fill="rgb(0,0,0)"/>
+  <polygon points="168 0 168 50 169 50 169 0" fill="rgb(0,0,0)"/>
+  <polygon points="170 0 170 50 171 50 171 0" fill="rgb(0,0,0)"/>
+  <polygon points="172 0 172 50 175 50 175 0" fill="rgb(0,0,0)"/>
+  <polygon points="178 0 178 50 179 50 179 0" fill="rgb(0,0,0)"/>
+  <polygon points="180 0 180 50 183 50 183 0" fill="rgb(0,0,0)"/>
+  <polygon points="184 0 184 50 185 50 185 0" fill="rgb(0,0,0)"/>
+  <polygon points="186 0 186 50 187 50 187 0" fill="rgb(0,0,0)"/>
+  <polygon points="190 0 190 50 191 50 191 0" fill="rgb(0,0,0)"/>
+  <polygon points="192 0 192 50 195 50 195 0" fill="rgb(0,0,0)"/>
+  <polygon points="196 0 196 50 199 50 199 0" fill="rgb(0,0,0)"/>
+  <polygon points="200 0 200 50 201 50 201 0" fill="rgb(0,0,0)"/>
+  <text x="105" y="61" color="rgb(0,0,0)" font-size="12" style="text-anchor: middle" transform="rotate(0, 105, 61)">*0123456789*</text>
+</svg>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Windows uses `\r\n` as a new-line symbol while DOMDocument returns file with `\n`. Because of that, we get untrue failures in tests.
