### PR TITLE
Get rid of risky tests - adds `doesNotPerformAssertions ` annotation

### DIFF
--- a/test/Renderer/ImageTest.php
+++ b/test/Renderer/ImageTest.php
@@ -38,7 +38,8 @@ class ImageTest extends TestCommon
     public function testGoodImageResource()
     {
         $imageResource = imagecreatetruecolor(1, 1);
-        $this->renderer->setResource($imageResource);
+        $renderer = $this->renderer->setResource($imageResource);
+        $this->assertSame($this->renderer, $renderer);
     }
 
     public function testObjectImageResource()

--- a/test/Renderer/ImageTest.php
+++ b/test/Renderer/ImageTest.php
@@ -35,11 +35,13 @@ class ImageTest extends TestCommon
         $this->assertSame('image', $this->renderer->getType());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testGoodImageResource()
     {
         $imageResource = imagecreatetruecolor(1, 1);
-        $renderer = $this->renderer->setResource($imageResource);
-        $this->assertSame($this->renderer, $renderer);
+        $this->renderer->setResource($imageResource);
     }
 
     public function testObjectImageResource()

--- a/test/Renderer/SvgTest.php
+++ b/test/Renderer/SvgTest.php
@@ -109,7 +109,8 @@ class SvgTest extends TestCommon
     public function testGoodSvgResource()
     {
         $svgResource = new \DOMDocument();
-        $this->renderer->setResource($svgResource, 10);
+        $renderer = $this->renderer->setResource($svgResource, 10);
+        $this->assertSame($this->renderer, $renderer);
     }
 
     public function testDrawReturnResource()

--- a/test/Renderer/SvgTest.php
+++ b/test/Renderer/SvgTest.php
@@ -106,11 +106,13 @@ class SvgTest extends TestCommon
         $this->renderer->setWidth(-1);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testGoodSvgResource()
     {
         $svgResource = new \DOMDocument();
-        $renderer = $this->renderer->setResource($svgResource, 10);
-        $this->assertSame($this->renderer, $renderer);
+        $this->renderer->setResource($svgResource, 10);
     }
 
     public function testDrawReturnResource()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
 Right now, when running tests, we get a message about two risky tests. Thanks to this PR that will no longer happen. Also, we will be sure that the object returned by setter is the same as the original one.