### PR TITLE
FIX `num_points` parameter deprecation in `imagepolygon()`

### DIFF
--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -498,7 +498,10 @@ class Image extends AbstractRenderer
     protected function imageFilledPolygonWrapper($image, array $points, $numPoints, $color, $filled)
     {
         if (! $filled) {
-            return imagepolygon($this->resource, $points, $numPoints, $color);
+            if (PHP_VERSION_ID < 80100) {
+                return imagepolygon($this->resource, $points, $numPoints, $color);
+            }
+            return imagepolygon($this->resource, $points, $color);
         }
 
         if (PHP_VERSION_ID < 80100) {

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -39,7 +39,6 @@ use function strlen;
 
 use const E_WARNING;
 use const PHP_MAJOR_VERSION;
-use const PHP_VERSION_ID;
 
 /**
  * Class for rendering the barcode as image
@@ -397,7 +396,7 @@ class Image extends AbstractRenderer
             $color & 0x0000FF
         );
 
-        $this->imageFilledPolygonWrapper($this->resource, $newPoints, 4, $allocatedColor, $filled);
+        $this->imageFilledPolygonWrapper($this->resource, $newPoints, $allocatedColor, $filled);
     }
 
     /**
@@ -490,22 +489,14 @@ class Image extends AbstractRenderer
     /**
      * @param GdImage|resource $image
      * @param array $points
-     * @param int $numPoints
      * @param int $color
      * @param bool $filled
      * @return bool
      */
-    protected function imageFilledPolygonWrapper($image, array $points, $numPoints, $color, $filled)
+    protected function imageFilledPolygonWrapper($image, array $points, $color, $filled)
     {
         if (! $filled) {
-            if (PHP_VERSION_ID < 80100) {
-                return imagepolygon($this->resource, $points, $numPoints, $color);
-            }
             return imagepolygon($this->resource, $points, $color);
-        }
-
-        if (PHP_VERSION_ID < 80100) {
-            return imagefilledpolygon($image, $points, $numPoints, $color);
         }
 
         return imagefilledpolygon($image, $points, $color);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -55,12 +55,10 @@ class FactoryTest extends TestCase
         $r = new ReflectionClass(Barcode\Barcode::class);
 
         $rObjectPlugins = $r->getProperty('objectPlugins');
-        $rObjectPlugins->setAccessible(true);
-        $rObjectPlugins->setValue(null);
+        $rObjectPlugins->setValue($r, null);
 
         $rRendererPlugins = $r->getProperty('rendererPlugins');
-        $rRendererPlugins->setAccessible(true);
-        $rRendererPlugins->setValue(null);
+        $rRendererPlugins->setValue($r, null);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The parameter `num_points` has been deprecated in PHP 8.1
https://www.php.net/manual/en/function.imagepolygon.php
```
Error [8192]: imagepolygon(): Using the $num_points parameter is deprecated in /var/www/vendor/laminas/laminas-barcode/src/Renderer/Image.php on line 501
```
